### PR TITLE
Fix class members scoring

### DIFF
--- a/tests/output.js
+++ b/tests/output.js
@@ -5,6 +5,10 @@ class Pizza {
     return 'Everybody'
   }
 
+  slicesCount = 5
+
+  _ingredients = ['cheese']
+
   constructor() {
     this._ingredients = ['cheese']
   }

--- a/tests/sample.js
+++ b/tests/sample.js
@@ -10,6 +10,8 @@ class Pizza {
 
   static sizes = ['7″', '10″']
 
+  _ingredients = ['cheese']
+
   static whoLovesPizzas() {
     return 'Everybody'
   }
@@ -17,4 +19,6 @@ class Pizza {
   constructor() {
     this._ingredients = ['cheese']
   }
+
+  slicesCount = 5
 }


### PR DESCRIPTION
This PR fixes class members scoring.

Private properties (prefixed with `_`) should be behind public properties.

See extended test.